### PR TITLE
Replace jurisdiction and pobox

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/ExceptionRecordTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/ExceptionRecordTest.java
@@ -17,7 +17,8 @@ public class ExceptionRecordTest {
     public void should_upload_blob_and_create_exception_record() throws Exception {
         var zipArchive = ZipFileHelper.createZipArchive(
             singletonList("test-data/exception/1111002.pdf"),
-            "test-data/exception/metadata.json"
+            "test-data/exception/metadata.json",
+            Container.BULKSCAN
         );
 
         StorageHelper.uploadZipFile(Container.BULKSCAN, zipArchive);
@@ -32,7 +33,8 @@ public class ExceptionRecordTest {
 
         var zipArchive = ZipFileHelper.createZipArchive(
             singletonList("test-data/supplementary_evidence_with_ocr/1111002.pdf"),
-            "test-data/supplementary_evidence_with_ocr/metadata.json"
+            "test-data/supplementary_evidence_with_ocr/metadata.json",
+            Container.BULKSCAN
         );
 
         StorageHelper.uploadZipFile(Container.BULKSCAN, zipArchive);
@@ -50,7 +52,8 @@ public class ExceptionRecordTest {
 
         var zipArchive = ZipFileHelper.createZipArchive(
             singletonList("test-data/supplementary_evidence/1111002.pdf"),
-            "test-data/supplementary_evidence/metadata.json"
+            "test-data/supplementary_evidence/metadata.json",
+            Container.BULKSCAN
         );
 
         StorageHelper.uploadZipFile(Container.BULKSCAN, zipArchive);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/ExceptionRecordTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/ExceptionRecordTest.java
@@ -72,7 +72,8 @@ public class ExceptionRecordTest {
 
         var zipArchive = ZipFileHelper.createZipArchive(
             singletonList("test-data/new_application/1111002.pdf"),
-            "test-data/new_application/metadata.json"
+            "test-data/new_application/metadata.json",
+            Container.BULKSCAN
         );
 
         StorageHelper.uploadZipFile(Container.BULKSCAN, zipArchive);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/NewApplicationPaymentsTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/NewApplicationPaymentsTest.java
@@ -15,7 +15,8 @@ public class NewApplicationPaymentsTest {
 
         var zipArchive = ZipFileHelper.createZipArchive(
             singletonList("test-data/new-application-payments/1111002.pdf"),
-            "test-data/new-application-payments/metadata.json"
+            "test-data/new-application-payments/metadata.json",
+            Container.BULKSCAN
         );
 
         StorageHelper.uploadZipFile(Container.BULKSCAN, zipArchive);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/Container.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/Container.java
@@ -2,7 +2,13 @@ package uk.gov.hmcts.reform.bulkscan.endtoendtests.helper;
 
 public enum Container {
 
-    BULKSCAN("bulkscan");
+    BULKSCAN("bulkscan"),
+    CMC("cmc"),
+    DIVORCE("divorce"),
+    FINREM("finrem"),
+    PROBATE("probate"),
+    PUBLICLAW("publiclaw"),
+    SSCS("sscs");
 
     public final String name;
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.endtoendtests.helper;
 
 import com.google.common.io.Resources;
 import org.apache.commons.io.FilenameUtils;
+import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ContainerJurisdictionPoBoxMapper;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -32,15 +33,22 @@ public final class ZipFileHelper {
 
     public static ZipArchive createZipArchive(
         List<String> pdfFiles,
-        String metadataFile
+        String metadataFile,
+        Container container
     ) throws Exception {
         String zipFileName = String.format(
             "%s_%s.test.zip",
             ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE),
             LocalDateTime.now().format(FILE_NAME_DATE_TIME_FORMAT)
         );
+        var containerMapping = ContainerJurisdictionPoBoxMapper.getMappedContainerData(container);
 
-        String metadataContent = updateMetadata(metadataFile, zipFileName);
+        String metadataContent = updateMetadata(
+            metadataFile,
+            zipFileName,
+            containerMapping.jurisdiction,
+            containerMapping.poBox
+        );
 
         byte[] zipContents = createZipArchiveWithDocumentsAndMetadata(pdfFiles, metadataContent);
 
@@ -84,7 +92,9 @@ public final class ZipFileHelper {
 
     private static String updateMetadata(
         String metadataFile,
-        String zipFileName
+        String zipFileName,
+        String jurisdiction,
+        String poBox
     ) throws Exception {
         assertThat(metadataFile).isNotBlank();
 
@@ -93,7 +103,9 @@ public final class ZipFileHelper {
 
         return metadataTemplate
             .replace("$$zip_file_name$$", zipFileName)
-            .replace("$$dcn1$$", generateDcnNumber());
+            .replace("$$dcn1$$", generateDcnNumber())
+            .replace("$$jurisdiction$$", jurisdiction)
+            .replace("$$po_box$$", poBox);
     }
 
     private static String generateDcnNumber() {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -40,7 +40,7 @@ public final class ZipFileHelper {
             LocalDateTime.now().format(FILE_NAME_DATE_TIME_FORMAT)
         );
 
-        String metadataContent = updateMetadataWithFileNameAndDcns(metadataFile, zipFileName);
+        String metadataContent = updateMetadata(metadataFile, zipFileName);
 
         byte[] zipContents = createZipArchiveWithDocumentsAndMetadata(pdfFiles, metadataContent);
 
@@ -82,8 +82,9 @@ public final class ZipFileHelper {
         return outputStream.toByteArray();
     }
 
-    public static String updateMetadataWithFileNameAndDcns(
-        String metadataFile, String zipFileName
+    private static String updateMetadata(
+        String metadataFile,
+        String zipFileName
     ) throws Exception {
         assertThat(metadataFile).isNotBlank();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.bulkscan.endtoendtests.utils;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.Container;
+
+import java.util.Map;
+
+public final class ContainerJurisdictionPoBoxMapper {
+
+    private static final Map<Container, JurisdictionAndPoBox> CONTAINER_MAPPINGS = ImmutableMap
+        .<Container, JurisdictionAndPoBox>builder()
+        .put(Container.BULKSCAN, new JurisdictionAndPoBox(Container.BULKSCAN.name(), "BULKSCANPO"))
+        .put(Container.CMC, new JurisdictionAndPoBox(Container.CMC.name(), "12747"))
+        .put(Container.DIVORCE, new JurisdictionAndPoBox(Container.DIVORCE.name(), "12706"))
+        .put(Container.FINREM, new JurisdictionAndPoBox(Container.DIVORCE.name(), "12746"))
+        .put(Container.PROBATE, new JurisdictionAndPoBox(Container.PROBATE.name(), "12625"))
+        .put(Container.PUBLICLAW, new JurisdictionAndPoBox(Container.PUBLICLAW.name(), "12879"))
+        .put(Container.SSCS, new JurisdictionAndPoBox(Container.SSCS.name(), "12626"))
+        .build();
+
+    private ContainerJurisdictionPoBoxMapper() {
+        // utility class construct
+    }
+
+    // name is as is in case we need to include more mapped data
+    public static JurisdictionAndPoBox getMappedContainerData(Container container) {
+        return CONTAINER_MAPPINGS.get(container);
+    }
+
+    public static class JurisdictionAndPoBox {
+
+        public final String jurisdiction;
+
+        public final String poBox;
+
+        private JurisdictionAndPoBox(
+            String jurisdiction,
+            String poBox
+        ) {
+            this.jurisdiction = jurisdiction;
+            this.poBox = poBox;
+        }
+    }
+}

--- a/src/functionalTest/resources/test-data/exception/metadata.json
+++ b/src/functionalTest/resources/test-data/exception/metadata.json
@@ -1,7 +1,7 @@
 {
   "case_number": "",
-  "po_box": "BULKSCANPO",
-  "jurisdiction": "BULKSCAN",
+  "po_box": "$$po_box$$",
+  "jurisdiction": "$$jurisdiction$$",
   "delivery_date": "2018-06-23T00:00:00.000Z",
   "opening_date": "2018-06-24T00:00:00.000Z",
   "zip_file_createddate": "2018-02-24T00:00:00.000Z",

--- a/src/functionalTest/resources/test-data/new-application-payments/metadata.json
+++ b/src/functionalTest/resources/test-data/new-application-payments/metadata.json
@@ -1,7 +1,7 @@
 {
   "case_number": "",
-  "po_box": "BULKSCANPO",
-  "jurisdiction": "BULKSCAN",
+  "po_box": "$$po_box$$",
+  "jurisdiction": "$$jurisdiction$$",
   "delivery_date": "2018-06-23T00:00:00.000Z",
   "opening_date": "2018-06-24T00:00:00.000Z",
   "zip_file_createddate": "2018-02-24T00:00:00.000Z",

--- a/src/functionalTest/resources/test-data/new_application/metadata.json
+++ b/src/functionalTest/resources/test-data/new_application/metadata.json
@@ -1,7 +1,7 @@
 {
   "case_number": "",
-  "po_box": "BULKSCANPO",
-  "jurisdiction": "BULKSCAN",
+  "po_box": "$$po_box$$",
+  "jurisdiction": "$$jurisdiction$$",
   "delivery_date": "2018-06-23T00:00:00.000Z",
   "opening_date": "2018-06-24T00:00:00.000Z",
   "zip_file_createddate": "2018-02-24T00:00:00.000Z",

--- a/src/functionalTest/resources/test-data/supplementary_evidence/metadata.json
+++ b/src/functionalTest/resources/test-data/supplementary_evidence/metadata.json
@@ -1,6 +1,6 @@
 {
-  "po_box": "BULKSCANPO",
-  "jurisdiction": "BULKSCAN",
+  "po_box": "$$po_box$$",
+  "jurisdiction": "$$jurisdiction$$",
   "delivery_date": "2018-06-23T00:00:00.000Z",
   "opening_date": "2018-06-24T00:00:00.000Z",
   "zip_file_createddate": "2018-02-24T00:00:00.000Z",

--- a/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
+++ b/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
@@ -1,6 +1,6 @@
 {
-  "po_box": "BULKSCANPO",
-  "jurisdiction": "BULKSCAN",
+  "po_box": "$$po_box$$",
+  "jurisdiction": "$$jurisdiction$$",
   "delivery_date": "2018-06-23T00:00:00.000Z",
   "opening_date": "2018-06-24T00:00:00.000Z",
   "zip_file_createddate": "2018-02-24T00:00:00.000Z",


### PR DESCRIPTION
### Change description ###

Making jurisdiction and po box "dynamic" fields in json file. Will be used once all services onboard. Changes involved:

- complete container list
- container mappings which atm need jurisdiction and pobox only
- apply feature in current tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
