### PR TITLE
Add OCR data encoder

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.endtoendtests.helper;
 import com.google.common.io.Resources;
 import org.apache.commons.io.FilenameUtils;
 import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ContainerJurisdictionPoBoxMapper;
+import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.OcrDataEncoder;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -42,12 +43,14 @@ public final class ZipFileHelper {
             LocalDateTime.now().format(FILE_NAME_DATE_TIME_FORMAT)
         );
         var containerMapping = ContainerJurisdictionPoBoxMapper.getMappedContainerData(container);
+        var ocrData = OcrDataEncoder.encodeDefaultOcrData(container);
 
         String metadataContent = updateMetadata(
             metadataFile,
             zipFileName,
             containerMapping.jurisdiction,
-            containerMapping.poBox
+            containerMapping.poBox,
+            ocrData
         );
 
         byte[] zipContents = createZipArchiveWithDocumentsAndMetadata(pdfFiles, metadataContent);
@@ -94,7 +97,8 @@ public final class ZipFileHelper {
         String metadataFile,
         String zipFileName,
         String jurisdiction,
-        String poBox
+        String poBox,
+        String ocrData
     ) throws Exception {
         assertThat(metadataFile).isNotBlank();
 
@@ -105,7 +109,8 @@ public final class ZipFileHelper {
             .replace("$$zip_file_name$$", zipFileName)
             .replace("$$dcn1$$", generateDcnNumber())
             .replace("$$jurisdiction$$", jurisdiction)
-            .replace("$$po_box$$", poBox);
+            .replace("$$po_box$$", poBox)
+            .replace("$$ocr_data$$", ocrData);
     }
 
     private static String generateDcnNumber() {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/OcrDataEncoder.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/OcrDataEncoder.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.bulkscan.endtoendtests.utils;
+
+import com.google.common.io.Resources;
+import uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.Container;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public final class OcrDataEncoder {
+
+    private OcrDataEncoder() {
+        // utility class construct
+    }
+
+    public static String encodeDefaultOcrData(Container container) throws IOException {
+        return Base64
+            .getEncoder()
+            .encodeToString(
+                Resources.toByteArray(
+                    Resources.getResource("ocr-data/" + container + ".json")
+                )
+            );
+    }
+}

--- a/src/functionalTest/resources/ocr-data/bulkscan.json
+++ b/src/functionalTest/resources/ocr-data/bulkscan.json
@@ -1,0 +1,16 @@
+{
+  "Metadata_file": [
+    {
+      "metadata_field_name": "first_name",
+      "metadata_field_value": "John"
+    },
+    {
+      "metadata_field_name": "last_name",
+      "metadata_field_value": "Smith"
+    },
+    {
+      "metadata_field_name": "date_of_birth",
+      "metadata_field_value": "1985-03-20"
+    }
+  ]
+}

--- a/src/functionalTest/resources/test-data/new-application-payments/metadata.json
+++ b/src/functionalTest/resources/test-data/new-application-payments/metadata.json
@@ -15,7 +15,7 @@
         "manual_intervention": "test",
         "next_action": "return",
         "next_action_date": "2018-06-23T00:00:00.000Z",
-        "ocr_data": "ewogICJNZXRhZGF0YV9maWxlIjogWwogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJmaXJzdF9uYW1lIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIkpvaG4iCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJsYXN0X25hbWUiLAogICAgICAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiU21pdGgiCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJkYXRlX29mX2JpcnRoIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIjE5ODUtMDMtMjAiCiAgICB9CiAgXQp9Cg==",
+        "ocr_data": "$$ocr_data$$",
         "file_name": "1111002.pdf",
         "notes": "test",
         "document_sub_type": "PERSONAL",

--- a/src/functionalTest/resources/test-data/new_application/metadata.json
+++ b/src/functionalTest/resources/test-data/new_application/metadata.json
@@ -15,7 +15,7 @@
       "manual_intervention": "test",
       "next_action": "return",
       "next_action_date": "2018-06-23T00:00:00.000Z",
-      "ocr_data": "ewogICJNZXRhZGF0YV9maWxlIjogWwogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJmaXJzdF9uYW1lIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIkpvaG4iCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJsYXN0X25hbWUiLAogICAgICAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiU21pdGgiCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJkYXRlX29mX2JpcnRoIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIjE5ODUtMDMtMjAiCiAgICB9CiAgXQp9Cg==",
+      "ocr_data": "$$ocr_data$$",
       "file_name": "1111002.pdf",
       "notes": "test",
       "document_type": "Form",

--- a/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
+++ b/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
@@ -14,7 +14,7 @@
         "manual_intervention": "string",
         "next_action": "return",
         "next_action_date": "2018-06-24T00:00:00.000Z",
-        "ocr_data": "ewogICJNZXRhZGF0YV9maWxlIjogWwogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJmaXJzdF9uYW1lIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIkpvaG4iCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJsYXN0X25hbWUiLAogICAgICAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiU21pdGgiCiAgICB9LAogICAgewogICAgICAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJkYXRlX29mX2JpcnRoIiwKICAgICAgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIjE5ODUtMDMtMjAiCiAgICB9CiAgXQp9Cg==",
+        "ocr_data": "$$ocr_data$$",
         "file_name": "1111002.pdf",
         "notes": "",
         "document_type": "Form",


### PR DESCRIPTION
### JIRA link (if applicable) ###

[End-to-end tests for all services](https://tools.hmcts.net/jira/browse/BPS-1250)

### Change description ###

Each service will have different set of OCR data. Moving out of metafile and adding replacement functionality

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
