### PR TITLE
Replace form type aka document subtype

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -66,6 +66,7 @@ public final class ZipFileHelper {
             zipFileName,
             containerMapping.jurisdiction,
             containerMapping.poBox,
+            containerMapping.formType,
             ocrData
         );
 
@@ -114,6 +115,7 @@ public final class ZipFileHelper {
         String zipFileName,
         String jurisdiction,
         String poBox,
+        String formType,
         String ocrData
     ) throws Exception {
         assertThat(metadataFile).isNotBlank();
@@ -126,6 +128,7 @@ public final class ZipFileHelper {
             .replace("$$dcn1$$", generateDcnNumber())
             .replace("$$jurisdiction$$", jurisdiction)
             .replace("$$po_box$$", poBox)
+            .replace("$$form_type$$", formType)
             .replace("$$ocr_data$$", ocrData);
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
@@ -9,13 +9,13 @@ public final class ContainerJurisdictionPoBoxMapper {
 
     private static final Map<Container, ContainerMapping> CONTAINER_MAPPINGS = ImmutableMap
         .<Container, ContainerMapping>builder()
-        .put(Container.BULKSCAN, new ContainerMapping(Container.BULKSCAN.name(), "BULKSCANPO"))
+        .put(Container.BULKSCAN, new ContainerMapping(Container.BULKSCAN.name(), "BULKSCANPO", "PERSONAL"))
         .put(Container.CMC, new ContainerMapping(Container.CMC.name(), "12747"))
-        .put(Container.DIVORCE, new ContainerMapping(Container.DIVORCE.name(), "12706"))
-        .put(Container.FINREM, new ContainerMapping(Container.DIVORCE.name(), "12746"))
-        .put(Container.PROBATE, new ContainerMapping(Container.PROBATE.name(), "12625"))
+        .put(Container.DIVORCE, new ContainerMapping(Container.DIVORCE.name(), "12706", "D8"))
+        .put(Container.FINREM, new ContainerMapping(Container.DIVORCE.name(), "12746", "FormA"))
+        .put(Container.PROBATE, new ContainerMapping(Container.PROBATE.name(), "12625", "PA8A"))
         .put(Container.PUBLICLAW, new ContainerMapping(Container.PUBLICLAW.name(), "12879"))
-        .put(Container.SSCS, new ContainerMapping(Container.SSCS.name(), "12626"))
+        .put(Container.SSCS, new ContainerMapping(Container.SSCS.name(), "12626", "SSCS1"))
         .build();
 
     private ContainerJurisdictionPoBoxMapper() {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
@@ -33,12 +33,20 @@ public final class ContainerJurisdictionPoBoxMapper {
 
         public final String poBox;
 
+        public final String formType;
+
         private ContainerMapping(
             String jurisdiction,
-            String poBox
+            String poBox,
+            String formType
         ) {
             this.jurisdiction = jurisdiction;
             this.poBox = poBox;
+            this.formType = formType;
+        }
+
+        private ContainerMapping(String jurisdiction, String poBox) {
+            this(jurisdiction, poBox, null);
         }
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
@@ -7,15 +7,15 @@ import java.util.Map;
 
 public final class ContainerJurisdictionPoBoxMapper {
 
-    private static final Map<Container, JurisdictionAndPoBox> CONTAINER_MAPPINGS = ImmutableMap
-        .<Container, JurisdictionAndPoBox>builder()
-        .put(Container.BULKSCAN, new JurisdictionAndPoBox(Container.BULKSCAN.name(), "BULKSCANPO"))
-        .put(Container.CMC, new JurisdictionAndPoBox(Container.CMC.name(), "12747"))
-        .put(Container.DIVORCE, new JurisdictionAndPoBox(Container.DIVORCE.name(), "12706"))
-        .put(Container.FINREM, new JurisdictionAndPoBox(Container.DIVORCE.name(), "12746"))
-        .put(Container.PROBATE, new JurisdictionAndPoBox(Container.PROBATE.name(), "12625"))
-        .put(Container.PUBLICLAW, new JurisdictionAndPoBox(Container.PUBLICLAW.name(), "12879"))
-        .put(Container.SSCS, new JurisdictionAndPoBox(Container.SSCS.name(), "12626"))
+    private static final Map<Container, ContainerMapping> CONTAINER_MAPPINGS = ImmutableMap
+        .<Container, ContainerMapping>builder()
+        .put(Container.BULKSCAN, new ContainerMapping(Container.BULKSCAN.name(), "BULKSCANPO"))
+        .put(Container.CMC, new ContainerMapping(Container.CMC.name(), "12747"))
+        .put(Container.DIVORCE, new ContainerMapping(Container.DIVORCE.name(), "12706"))
+        .put(Container.FINREM, new ContainerMapping(Container.DIVORCE.name(), "12746"))
+        .put(Container.PROBATE, new ContainerMapping(Container.PROBATE.name(), "12625"))
+        .put(Container.PUBLICLAW, new ContainerMapping(Container.PUBLICLAW.name(), "12879"))
+        .put(Container.SSCS, new ContainerMapping(Container.SSCS.name(), "12626"))
         .build();
 
     private ContainerJurisdictionPoBoxMapper() {
@@ -23,17 +23,17 @@ public final class ContainerJurisdictionPoBoxMapper {
     }
 
     // name is as is in case we need to include more mapped data
-    public static JurisdictionAndPoBox getMappedContainerData(Container container) {
+    public static ContainerMapping getMappedContainerData(Container container) {
         return CONTAINER_MAPPINGS.get(container);
     }
 
-    public static class JurisdictionAndPoBox {
+    public static class ContainerMapping {
 
         public final String jurisdiction;
 
         public final String poBox;
 
-        private JurisdictionAndPoBox(
+        private ContainerMapping(
             String jurisdiction,
             String poBox
         ) {

--- a/src/functionalTest/resources/test-data/new-application-payments/metadata.json
+++ b/src/functionalTest/resources/test-data/new-application-payments/metadata.json
@@ -18,7 +18,7 @@
         "ocr_data": "$$ocr_data$$",
         "file_name": "1111002.pdf",
         "notes": "test",
-        "document_sub_type": "PERSONAL",
+        "document_sub_type": "$$form_type$$",
         "document_type": "Form"
       }
   ],

--- a/src/functionalTest/resources/test-data/new_application/metadata.json
+++ b/src/functionalTest/resources/test-data/new_application/metadata.json
@@ -19,7 +19,7 @@
       "file_name": "1111002.pdf",
       "notes": "test",
       "document_type": "Form",
-      "document_sub_type": "PERSONAL"
+      "document_sub_type": "$$form_type$$"
     }
   ]
 }

--- a/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
+++ b/src/functionalTest/resources/test-data/supplementary_evidence_with_ocr/metadata.json
@@ -18,7 +18,7 @@
         "file_name": "1111002.pdf",
         "notes": "",
         "document_type": "Form",
-        "document_sub_type": "PERSONAL"
+        "document_sub_type": "$$form_type$$"
       }
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[End-to-end tests for all services](https://tools.hmcts.net/jira/browse/BPS-1250)

### Change description ###

As part of new application for services we need to also amend form type. Adding currently onboarded services. Default will be `null` and will/should not be used

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
