### PR TITLE
fix payment dcn length

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -123,21 +123,24 @@ public final class ZipFileHelper {
 
         return metadataTemplate
             .replace("$$zip_file_name$$", zipFileName)
-            .replace("$$dcn1$$", generateDcnNumber())
+            .replace("$$dcn1$$", generateDocumentDcnNumber())
             .replace("$$payment_dcn$$", generatePaymentDcnNumber())
             .replace("$$jurisdiction$$", jurisdiction)
             .replace("$$po_box$$", poBox)
             .replace("$$ocr_data$$", ocrData);
     }
 
-    private static String generateDcnNumber() {
-        return Long.toString(System.currentTimeMillis()) + Math.abs(RANDOM.nextInt());
+    private static String generateDocumentDcnNumber() {
+        return generateDcnNumber(17);
     }
 
     private static String generatePaymentDcnNumber() {
-        return (Long.toString(System.nanoTime()) + System.nanoTime()).substring(0, 21);
+        return generateDcnNumber(21);
     }
 
+    private static String generateDcnNumber(int length) {
+        return (Long.toString(System.nanoTime()) + System.nanoTime()).substring(0, length);
+    }
     public static class ZipArchive {
         public final String fileName;
         public final byte[] content;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -124,6 +124,7 @@ public final class ZipFileHelper {
         return metadataTemplate
             .replace("$$zip_file_name$$", zipFileName)
             .replace("$$dcn1$$", generateDcnNumber())
+            .replace("$$payment_dcn$$", generatePaymentDcnNumber())
             .replace("$$jurisdiction$$", jurisdiction)
             .replace("$$po_box$$", poBox)
             .replace("$$ocr_data$$", ocrData);
@@ -131,6 +132,10 @@ public final class ZipFileHelper {
 
     private static String generateDcnNumber() {
         return Long.toString(System.currentTimeMillis()) + Math.abs(RANDOM.nextInt());
+    }
+
+    private static String generatePaymentDcnNumber() {
+        return (Long.toString(System.nanoTime()) + System.nanoTime()).substring(0, 21);
     }
 
     public static class ZipArchive {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/ZipFileHelper.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -24,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public final class ZipFileHelper {
 
-    private static final Random RANDOM = new Random();
     public static final String ENVELOPE_ZIPFILE_NAME = "envelope.zip";
     public static final String SIGNATURE_FILE_NAME = "signature";
 
@@ -141,6 +139,7 @@ public final class ZipFileHelper {
     private static String generateDcnNumber(int length) {
         return (Long.toString(System.nanoTime()) + System.nanoTime()).substring(0, length);
     }
+
     public static class ZipArchive {
         public final String fileName;
         public final byte[] content;

--- a/src/functionalTest/resources/test-data/new-application-payments/metadata.json
+++ b/src/functionalTest/resources/test-data/new-application-payments/metadata.json
@@ -24,7 +24,7 @@
   ],
   "payments": [
       {
-        "document_control_number": "$$dcn1$$"
+        "document_control_number": "$$payment_dcn$$"
       }
   ]
 }


### PR DESCRIPTION

### Change description ###

fix payment dcn length. payment dcn should be 21 digit.
existing DCN generater generate variable length between 20-23.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
