### PR TITLE
Fix NPE when used null value for map builders

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/utils/ContainerJurisdictionPoBoxMapper.java
@@ -46,7 +46,9 @@ public final class ContainerJurisdictionPoBoxMapper {
         }
 
         private ContainerMapping(String jurisdiction, String poBox) {
-            this(jurisdiction, poBox, null);
+            // NONE for form type - otherwise tools complain why it's null.
+            // Should not be used anyway and we'll get failure if we do use it for on-boarded services
+            this(jurisdiction, poBox, "NONE");
         }
     }
 }


### PR DESCRIPTION
### Change description ###

`ImmutableMap` from guava and `Map` from java both check for nulls on keys and values. Just passing dummy value instead `null`. We will fail e2e down the line anyway so let's just **not** use `null`s in the first place

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
