### PR TITLE
Add http policy to manually include custom content type header

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/StorageHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/helper/StorageHelper.java
@@ -45,6 +45,15 @@ public final class StorageHelper {
                                    )
                             )
                             .build())
+            // each policy is executed before sending out the request
+            .addPolicy(((context, next) -> {
+                context
+                    .getHttpRequest()
+                    .getHeaders()
+                    .put("Content-Type", "application/zip");
+
+                return next.process();
+            }))
             .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS))
             .buildClient()
             .getBlobClient(zipArchive.fileName)


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Make bulk scan end 2 end test more stable](https://tools.hmcts.net/jira/browse/BPS-1294)

### Change description ###

`application/octet-stream` is hardcoded and cannot override too easily (see below). Trying out http policy which is the idea to populate anything is "missing" in the request before sending it out. Each policy gets executed and last one is actual request to service bus

API uses generated proxies with severe annotations across each method call. the one we are interested in is a `ServiceInterface` with these (very few copied):

```java
@Put("{containerName}/{blob}")
@ExpectedResponses({201})
@UnexpectedResponseExceptionType(BlobStorageException.class)
Mono<BlockBlobsUploadResponse> upload(
    @PathParam("containerName") String containerName,
    @PathParam("blob") String blob,
    @HostParam("url") String url,
    @BodyParam("application/octet-stream") Flux<ByteBuffer> body,
    ...
    @HeaderParam("x-ms-blob-content-type") String contentType,
    ...
```

current code (which has a revert #100) tries to override it too but gets into another param in this method prefixed `x-ms-blob-`.

I have a blind hope that policy will allow to override this because http request and body will be already registered / batched up in the pipeline

P.S. I'm leaving revert out of this

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
