### PR TITLE
Updated cron frequency to run everyday at 9

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-  pipelineTriggers([cron('30 * * * *')])
+  pipelineTriggers([cron('H 09 * * *')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION
- Currently end to end tests are very unstable so running every 30 minutes is just adding to failure count.

- Temporarily changing the frequency so that less failures are logged.

- Once stable we can revert this PR.