### PR TITLE
DTSBPS-499 refactor for envelope id check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,3 @@ jobs:
           java-version: 11
       - name: Run checks
         run: ./gradlew check
-      - name: Run OWASP check
-        run: ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAnalyze

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/BulkScanAutoUpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/BulkScanAutoUpdateTest.java
@@ -8,10 +8,10 @@ import uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.ZipFileHelper;
 import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.EnvelopeAction;
 import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ProcessorEnvelopeResult;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.endtoendtests.client.CcdClient.assertCaseEnvelopes;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.Container.BULKSCAN_AUTO;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ProcessorEnvelopeStatusChecker.getZipFileStatus;
 
@@ -32,7 +32,7 @@ public class BulkScanAutoUpdateTest {
         ProcessorEnvelopeResult envCreate = getZipFileStatus(zipArchiveCreate.fileName).get();
         assertCompletedProcessorResult(envCreate, "AUTO_CREATED_CASE");
 
-        String ccdId = getZipFileStatus(zipArchiveCreate.fileName).get().ccdId;
+        String ccdId = envCreate.ccdId;
         Map<String, Object> caseDataCreated =
             CcdClient.getCaseData(ccdId, BULKSCAN_AUTO.idamUserName, BULKSCAN_AUTO.idamPassword);
         assertCaseFields(caseDataCreated, "Name", "Surname", "e2e@test.dev");
@@ -90,19 +90,5 @@ public class BulkScanAutoUpdateTest {
         assertThat(caseDetails.get("firstName")).isEqualTo(name);
         assertThat(caseDetails.get("lastName")).isEqualTo(surname);
         assertThat(caseDetails.get("email")).isEqualTo(email);
-    }
-
-    private void assertCaseEnvelopes(
-        Map<String, Object> caseDetails,
-        EnvelopeAction[] envelopeActions
-    ) {
-        List<Map<String, Object>> envelopes =
-            (List<Map<String, Object>>) caseDetails.get("bulkScanEnvelopes");
-        assertThat(envelopes.size()).isEqualTo(envelopeActions.length);
-        for (int i = 0; i < envelopeActions.length; i++) {
-            Map<String, String> values = (Map<String, String>) envelopes.get(i).get("value");
-            assertThat(values.get("id")).isEqualTo(envelopeActions[i].envelopeId);
-            assertThat(values.get("action")).isEqualTo(envelopeActions[i].action);
-        }
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/BulkScanAutoUpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/BulkScanAutoUpdateTest.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.reform.bulkscan.endtoendtests.client.CcdClient.assert
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.Container.BULKSCAN_AUTO;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ProcessorEnvelopeStatusChecker.getZipFileStatus;
 
-@SuppressWarnings("unchecked")
 public class BulkScanAutoUpdateTest {
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/client/CcdClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/client/CcdClient.java
@@ -4,12 +4,14 @@ import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 import uk.gov.hmcts.reform.bulkscan.endtoendtests.helper.Container;
 import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.ContainerJurisdictionPoBoxMapper;
+import uk.gov.hmcts.reform.bulkscan.endtoendtests.utils.EnvelopeAction;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -17,6 +19,7 @@ import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.client.IdamClient.getIdamToken;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.client.IdamClient.getUserId;
 import static uk.gov.hmcts.reform.bulkscan.endtoendtests.client.S2SClient.getS2SToken;
@@ -164,5 +167,19 @@ public class CcdClient {
             .header("experimental", true)
             .header("Authorization", BEARER_TOKEN_PREFIX + idamToken)
             .header("ServiceAuthorization", BEARER_TOKEN_PREFIX + s2sToken);
+    }
+
+    public static void assertCaseEnvelopes(
+        Map<String, Object> caseDetails,
+        EnvelopeAction[] envelopeActions
+    ) {
+        List<Map<String, Object>> envelopes =
+            (List<Map<String, Object>>) caseDetails.get("bulkScanEnvelopes");
+        assertThat(envelopes.size()).isEqualTo(envelopeActions.length);
+        for (int i = 0; i < envelopeActions.length; i++) {
+            Map<String, String> values = (Map<String, String>) envelopes.get(i).get("value");
+            assertThat(values.get("id")).isEqualTo(envelopeActions[i].envelopeId);
+            assertThat(values.get("action")).isEqualTo(envelopeActions[i].action);
+        }
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/client/CcdClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/endtoendtests/client/CcdClient.java
@@ -169,6 +169,7 @@ public class CcdClient {
             .header("ServiceAuthorization", BEARER_TOKEN_PREFIX + s2sToken);
     }
 
+    @SuppressWarnings("unchecked")
     public static void assertCaseEnvelopes(
         Map<String, Object> caseDetails,
         EnvelopeAction[] envelopeActions


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSBPS-499

### Change description ###

refactor to get ready to envelope id check in BulkScanAutoNewApplicationTest

*Disable owasp for now as it is broken.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
